### PR TITLE
Fix #171: Implement stopgap fix to overwriting.

### DIFF
--- a/notebooks/COS/DayNight/DayNight.ipynb
+++ b/notebooks/COS/DayNight/DayNight.ipynb
@@ -205,7 +205,21 @@
     "||||\n",
     "|***Combination***|`oi_1304 < 100 AND sun_alt <= 10 OR target_alt > 30`|Total irradiance about 1304 Å is less than 100 *AND* the Sun's altitude is less than or equal to 10˚ *OR* the target's altitude is above 30˚|\n",
     "\n",
-    "Note that in the combination above, the *\"OR\"* takes precedence: if a count does not satisfy both of the first 2 statements, but it does satisfy statement 3, it will be allowed to contribute to the spectrum."
+    "*Note* that in the combination above, the *\"OR\"* takes precedence: if a count does not satisfy both of the first 2 statements, but it does satisfy statement 3, it will be allowed to contribute to the spectrum."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Note* that the `TimelineFilter` function will not overwrite existing files, so if you wish to run the following cell more than once, you must delete the files you have already created in the `intermediate` directory. If you wish to do this repeatedly, you may wish to add something like the following to the top of the next code cell:\n",
+    "\n",
+    "```python\n",
+    "if os.path.exists(intermediate_dir / \"filtered_corrtag_a.fits\"): # Check if you have created a filtered FUVA file\n",
+    "    os.remove(intermediate_dir / \"filtered_corrtag_a.fits\")      #   if so, delete it so we can re-create it with TimelineFilter\n",
+    "if os.path.exists(intermediate_dir / \"filtered_corrtag_b.fits\"): # Repeat the above with FUVB file\n",
+    "    os.remove(intermediate_dir / \"filtered_corrtag_b.fits\")\n",
+    "```"
    ]
   },
   {


### PR DESCRIPTION
Implement stopgap fix to Issue #171:
* [#171](https://github.com/spacetelescope/notebooks/issues/171) describes the lack of overwrite functionality to costools.timefilter.TimelineFilter()
  * Until such functionality can be added (not yet scoped), implemented a suggestion to add a bit of code which: `if the files exist --> deletes them` so that the files can be re-created without errors
  * Purposefully left this code in a markdown cell, so that users would not accidentally delete their processed files, without reading the Note, and copying in the lines.